### PR TITLE
Revamp word learning flow

### DIFF
--- a/lib/screens/lesson_screen.dart
+++ b/lib/screens/lesson_screen.dart
@@ -50,29 +50,35 @@ class _LessonScreenState extends State<LessonScreen> {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Text('${_current + 1}/${words.length}'),
-                      if (_current < words.length - 1)
-                        ElevatedButton(
-                          onPressed: () {
-                            _controller.nextPage(
-                                duration: const Duration(milliseconds: 300),
-                                curve: Curves.easeInOut);
-                          },
-                          child: const Text('Далее'),
-                        )
-                      else
-                        ElevatedButton(
-                          onPressed: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                  builder: (_) => TrainingScreen(
-                                        words: words,
-                                        lesson: widget.lesson,
-                                      )),
-                            );
-                          },
-                          child: const Text('Перейти к тренировке'),
-                        )
+                      ElevatedButton(
+                        onPressed: words[_current].isLearned
+                            ? null
+                            : () {
+                                setState(() {
+                                  words[_current].isLearned = true;
+                                });
+                                ProgressService
+                                    .markWordsLearned([words[_current].id]);
+                                if (_current < words.length - 1) {
+                                  _controller.nextPage(
+                                      duration:
+                                          const Duration(milliseconds: 300),
+                                      curve: Curves.easeInOut);
+                                } else {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                        builder: (_) => TrainingScreen(
+                                              words: words,
+                                              lesson: widget.lesson,
+                                            )),
+                                  );
+                                }
+                              },
+                        child: Text(words[_current].isLearned
+                            ? 'Изучено ✅'
+                            : 'Изучено'),
+                      )
                     ],
                   ),
                 )

--- a/lib/widgets/word_card.dart
+++ b/lib/widgets/word_card.dart
@@ -15,16 +15,7 @@ class WordCard extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(word.arabic, style: const TextStyle(fontSize: 36)),
-                  IconButton(
-                    icon: const Icon(Icons.star_border),
-                    onPressed: () {},
-                  )
-                ],
-              ),
+              Text(word.arabic, style: const TextStyle(fontSize: 36)),
               const SizedBox(height: 16),
               Text(word.transcription, style: const TextStyle(fontSize: 20)),
               const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- clean up `WordCard` UI to remove favourites
- add per-word progress on lesson pages

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0fcf9f74833299b94964428714aa