### PR TITLE
Hide learned words

### DIFF
--- a/lib/screens/lesson_screen.dart
+++ b/lib/screens/lesson_screen.dart
@@ -23,7 +23,7 @@ class _LessonScreenState extends State<LessonScreen> {
   void initState() {
     super.initState();
     _controller = PageController();
-    _wordsFuture = WordService.loadWordsByLesson(widget.lesson);
+    _wordsFuture = WordService.loadUnlearnedWordsByLesson(widget.lesson);
   }
 
   @override
@@ -35,6 +35,9 @@ class _LessonScreenState extends State<LessonScreen> {
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             final words = snapshot.data!;
+            if (words.isEmpty) {
+              return const Center(child: Text('Все слова изучены'));
+            }
             return Column(
               children: [
                 Expanded(

--- a/lib/services/word_service.dart
+++ b/lib/services/word_service.dart
@@ -22,6 +22,11 @@ class WordService {
     return words.where((w) => w.lesson == lesson).toList();
   }
 
+  static Future<List<QuranWord>> loadUnlearnedWordsByLesson(int lesson) async {
+    final words = await loadWordsByLesson(lesson);
+    return words.where((w) => !w.isLearned).toList();
+  }
+
   static Future<int> lessonCount() async {
     final words = await loadWords();
     return words.map((w) => w.lesson).toSet().length;


### PR DESCRIPTION
## Summary
- hide already learned words in lesson view
- show a message when all words in lesson are learned
- support loading only unlearned words

## Testing
- `dart format lib/services/word_service.dart lib/screens/lesson_screen.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685000a92b348332a3ba3b4b834070cb