### PR TITLE
Fix lesson screen layout

### DIFF
--- a/lib/screens/lesson_screen.dart
+++ b/lib/screens/lesson_screen.dart
@@ -30,7 +30,8 @@ class _LessonScreenState extends State<LessonScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Урок ${widget.lesson}')),
-      body: FutureBuilder<List<QuranWord>>(
+      body: SafeArea(
+        child: FutureBuilder<List<QuranWord>>(
         future: _wordsFuture,
         builder: (context, snapshot) {
           if (snapshot.hasData) {
@@ -95,6 +96,7 @@ class _LessonScreenState extends State<LessonScreen> {
           }
         },
       ),
-    );
+    ),
+  );
   }
 }

--- a/lib/screens/lesson_screen.dart
+++ b/lib/screens/lesson_screen.dart
@@ -32,15 +32,17 @@ class _LessonScreenState extends State<LessonScreen> {
       appBar: AppBar(title: Text('Урок ${widget.lesson}')),
       body: SafeArea(
         child: FutureBuilder<List<QuranWord>>(
-        future: _wordsFuture,
-        builder: (context, snapshot) {
+          future: _wordsFuture,
+          builder: (context, snapshot) {
           if (snapshot.hasData) {
             final words = snapshot.data!;
             if (words.isEmpty) {
               return const Center(child: Text('Все слова изучены'));
             }
-            return Column(
-              children: [
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                return Column(
+                  children: [
                 Expanded(
                   child: PageView.builder(
                     controller: _controller,
@@ -87,8 +89,10 @@ class _LessonScreenState extends State<LessonScreen> {
                     ],
                   ),
                 )
-              ],
-            );
+                ],
+              );
+            },
+          );
           } else if (snapshot.hasError) {
             return Center(child: Text('Ошибка загрузки слов'));
           } else {


### PR DESCRIPTION
## Summary
- wrap `LessonScreen` body in `SafeArea`

## Testing
- `dart` or `flutter` unavailable in container

------
https://chatgpt.com/codex/tasks/task_e_68500479e46483329bde53f5e24ac5eb